### PR TITLE
feat(sse): implement SSE endpoint with auth, event broadcasting, and Santa assignment distribution

### DIFF
--- a/SecretSantaServer/SecretSantaServer/SecretSantaServer.csproj
+++ b/SecretSantaServer/SecretSantaServer/SecretSantaServer.csproj
@@ -14,6 +14,7 @@
         <PackageReference Include="EFCore.NamingConventions" Version="9.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Common" Version="10.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.11" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.11">
           <PrivateAssets>all</PrivateAssets>

--- a/SecretSantaServer/SecretSantaServer/appsettings.Development.json
+++ b/SecretSantaServer/SecretSantaServer/appsettings.Development.json
@@ -11,6 +11,9 @@
     "Key": "secret-key-for-testing-jwt-venom"
   },
   "Frontend": {
-    "AuthCallback": "http://localhost:5000/"
+    "AuthCallback": "http://localhost:5000/",
+    "GameStatusUpdatedMethod": "GameStatus",
+    "UserJoinMethod": "UserJoin",
+    "UserExitMethod": "UserExit"
   }
 }

--- a/SecretSantaServer/SecretSantaServer/src/Controllers/GameController.cs
+++ b/SecretSantaServer/SecretSantaServer/src/Controllers/GameController.cs
@@ -122,13 +122,26 @@ public class GameController : ControllerBase
         return Ok(result.Value);
     }
     
-    [HttpGet("{gameId}/members/{userId}/wish")]
+    [HttpGet("{gameId}/my-wish")]
     [Authorize]
-    public async Task<IActionResult> GetWishLetter(int gameId, int userId, WishLetterDto wishLetter)
+    public async Task<IActionResult> GetMyWishLetter(int gameId)
     {
-        var requesterId = GetUserId();
+        var userId = GetUserId();
         
-        var result = await _assignmentService.GetWishLetter(gameId, userId, requesterId);
+        var result = await _assignmentService.GetMyWishLetter(gameId, userId);
+        if (!result.IsSuccess)
+            return StatusCode(result.StatusCode, result.Error);
+
+        return Ok(result.Value);
+    }
+    
+    [HttpGet("{gameId}/participant/wish")]
+    [Authorize]
+    public async Task<IActionResult> GetParticipantWishLetter(int gameId)
+    {
+        var userId = GetUserId();
+        
+        var result = await _assignmentService.GetParticipantWishLetter(gameId, userId);
         if (!result.IsSuccess)
             return StatusCode(result.StatusCode, result.Error);
 

--- a/SecretSantaServer/SecretSantaServer/src/DTOs/EventDto.cs
+++ b/SecretSantaServer/SecretSantaServer/src/DTOs/EventDto.cs
@@ -1,0 +1,15 @@
+namespace SecretSantaServer.DTOs;
+
+public class EventDto<T>
+{
+    public string EventType { get; set; }
+    T Message { get; set; }
+    private int? PlayerId { get; set; } = null;
+    
+    public EventDto(string eventType, T gameId, int? playerId = null)
+    {
+        EventType = eventType;
+        Message = gameId;
+        PlayerId = playerId;
+    }
+}

--- a/SecretSantaServer/SecretSantaServer/src/DTOs/GameDto.cs
+++ b/SecretSantaServer/SecretSantaServer/src/DTOs/GameDto.cs
@@ -12,6 +12,7 @@ public class GameDto
 
     public int AdminId { get; set; }
     public IEnumerable<UserProfileDto> Members { get; set; }
+    public bool IsAdminParticipating { get; set; }
 
     public GameStatus Status { get; set; } = GameStatus.Created;
     public DateTime? StartsAt { get; set; }
@@ -26,12 +27,13 @@ public class GameDto
         Code = game.Code;
         AdminId = game.AdminId;
         Status = game.Status;
+        IsAdminParticipating = game.IsAdminParticipating;
         StartsAt = game.ScheduledAt;
         StartedAt = game.StartedAt;
         FinishedAt = game.FinishedAt;
         if (game.GameMembers == null || game.GameMembers.Count == 0)
             Members = null;
-        else if(game.GameMembers.ToList()[0].User!=null)
+        else if (game.GameMembers.ToList()[0].User != null)
             Members = game.GameMembers.Select(x => new UserProfileDto(x.User)).ToList();
     }
 }

--- a/SecretSantaServer/SecretSantaServer/src/DTOs/UpdateGameRequest.cs
+++ b/SecretSantaServer/SecretSantaServer/src/DTOs/UpdateGameRequest.cs
@@ -6,11 +6,10 @@ public class UpdateGameRequest
 {
     [Required, MinLength(4), MaxLength(64)]
     public string Title { get; set; }
-    
-    [MaxLength(512)]
-    public string? Description { get; set; }
 
-    public bool IsAdminParticipating;
-    
+    [MaxLength(512)] public string? Description { get; set; }
+
+    public bool IsAdminParticipating { get; set; }
+
     public DateTime? StartsAt { get; set; }
 }

--- a/SecretSantaServer/SecretSantaServer/src/Data/ApplicationDbContext.cs
+++ b/SecretSantaServer/SecretSantaServer/src/Data/ApplicationDbContext.cs
@@ -69,9 +69,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         });
         modelBuilder.Entity<Assignment>(assignment =>
         {
-            assignment.HasKey(x => x.RecipientId);
-
-            assignment.HasIndex(x => new { x.GameId, x.SantaId }).IsUnique();
+            assignment.HasKey(x => new{x.GameId, x.RecipientId, x.SantaId});
 
             assignment.HasOne(x => x.Recipient)
                 .WithMany()

--- a/SecretSantaServer/SecretSantaServer/src/Hubs/GameHub.cs
+++ b/SecretSantaServer/SecretSantaServer/src/Hubs/GameHub.cs
@@ -1,0 +1,36 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using SecretSantaServer.DTOs;
+using SecretSantaServer.Services;
+
+namespace SecretSantaServer.Hubs;
+
+[Authorize]
+public class GameHub : Hub
+{
+    private readonly IGameService _gameService;
+    private readonly string _gameStatusUpdateMethod;
+
+    public GameHub(IGameService gameService, IConfiguration configuration)
+    {
+        _gameService = gameService;
+        _gameStatusUpdateMethod = configuration["Fronted:GameStatusUpdateMethod"]!;
+    }
+
+    public async Task JoinGame(int gameId)
+    {
+        var userId = int.Parse(Context.User!.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+        if (!await _gameService.IsUserInGame(gameId, userId))
+        {
+            await Clients.Caller.SendAsync("Error", $"User {userId} not in game {gameId}");
+            return;
+        }
+
+        await Groups.AddToGroupAsync(Context.ConnectionId, $"game-{gameId}");
+
+        var currentStatus = await _gameService.GetGameStatusById(gameId);
+
+        await Clients.Caller.SendAsync(_gameStatusUpdateMethod, new EventDto<int>($"game-{currentStatus}", gameId));
+    }
+}

--- a/SecretSantaServer/SecretSantaServer/src/Program.cs
+++ b/SecretSantaServer/SecretSantaServer/src/Program.cs
@@ -21,6 +21,8 @@ builder.Services.AddScoped<IAuthService, AuthService>();
 builder.Services.AddHttpClient<GoogleOAuthClient>();
 builder.Services.AddHttpClient<GithubOAuthClient>();
 
+builder.Services.AddSignalR();
+
 var connectionString = builder.Configuration.GetConnectionString("PostgresConnection");
 builder.Services.AddDbContext<IDbContext, ApplicationDbContext>(options =>
     options.UseNpgsql(connectionString).UseSnakeCaseNamingConvention()

--- a/SecretSantaServer/SecretSantaServer/src/Services/AssignmentService.cs
+++ b/SecretSantaServer/SecretSantaServer/src/Services/AssignmentService.cs
@@ -15,44 +15,56 @@ public class AssignmentService : IAssignmentService
         _dbContext = dbContext;
     }
 
-    public async Task<Result<GameMemberDto>> GetWishLetter(int gameId, int userId, int requesterId)
+    public async Task<Result<GameMemberDto>> GetMyWishLetter(int gameId, int userId)
     {
-        var member=await _dbContext.GameMembers.AsNoTracking()
-            .Include(x=>x.User)
+        var member = await _dbContext.GameMembers.AsNoTracking()
+            .Include(x => x.User)
             .FirstOrDefaultAsync(g => g.GameId == gameId && g.UserId == userId);
-        if(member == null)
-            return Result<GameMemberDto>.Failure($"User {userId} not found", StatusCodes.Status404NotFound);
-        
-        if(userId == requesterId)
-            return Result<GameMemberDto>.Success(new GameMemberDto(member));
-        
-        var assignment = await _dbContext.Assignments.AsNoTracking()
-            .Include(x=>x.Recipient)
-            .FirstOrDefaultAsync(x=>x.GameId == gameId && x.RecipientId == userId);
-        if (assignment == null) 
-            return Result<GameMemberDto>.Failure("Assignment not found", StatusCodes.Status404NotFound);
-        
-        if(assignment.SantaId!=requesterId)
-            return Result<GameMemberDto>.Failure("You don't have access to this assignment", StatusCodes.Status403Forbidden);
-        
+        if (member == null)
+            return Result<GameMemberDto>.Failure($"User {userId} not found in game {gameId}",
+                StatusCodes.Status404NotFound);
+
         return Result<GameMemberDto>.Success(new GameMemberDto(member));
     }
-    
+
+    public async Task<Result<GameMemberDto>> GetParticipantWishLetter(int gameId, int userId)
+    {
+        var game = await _dbContext.Games.Include(x => x.GameMembers)
+            .ThenInclude(x => x.User).FirstOrDefaultAsync(x => x.Id == gameId);
+        if (game == null)
+            return Result<GameMemberDto>.Failure($"Game {gameId} not found", StatusCodes.Status404NotFound);
+
+        var member = game.GameMembers.FirstOrDefault(g => g.GameId == gameId && g.UserId == userId);
+        if (member == null)
+            return Result<GameMemberDto>.Failure($"User {userId} not found in game {gameId}",
+                StatusCodes.Status404NotFound);
+
+        var assignment = await _dbContext.Assignments.AsNoTracking()
+            .Include(x => x.Recipient)
+            .ThenInclude(x => x.User)
+            .FirstOrDefaultAsync(x => x.SantaId == member.Id);
+        if (assignment == null)
+            return Result<GameMemberDto>.Failure("Assignment not found", StatusCodes.Status404NotFound);
+
+        return Result<GameMemberDto>.Success(new GameMemberDto(assignment.Recipient));
+    }
+
     public async Task<Result<GameMemberDto>> ChangeWishLetter(int gameId, int userId, string wishLetter)
     {
-        var gameMember = await _dbContext.GameMembers.Include(x=>x.Game)
-            .Include(x=>x.User)
-            .FirstOrDefaultAsync(x=>x.GameId == gameId && x.UserId == userId);
-        if (gameMember == null) 
-            return Result<GameMemberDto>.Failure($"User {userId} not found in game {gameId}", StatusCodes.Status404NotFound);
-        
-        if(gameMember.Game.Status!=GameStatus.Created)
+        var gameMember = await _dbContext.GameMembers.Include(x => x.Game)
+            .Include(x => x.User)
+            .FirstOrDefaultAsync(x => x.GameId == gameId && x.UserId == userId);
+        if (gameMember == null)
+            return Result<GameMemberDto>.Failure($"User {userId} not found in game {gameId}",
+                StatusCodes.Status404NotFound);
+
+        if (gameMember.Game.Status != GameStatus.Created)
             return Result<GameMemberDto>.Failure("You can't change wish after the game has started.",
                 StatusCodes.Status400BadRequest);
         gameMember.Letter = wishLetter;
         _dbContext.GameMembers.Update(gameMember);
         await _dbContext.SaveChangesAsync();
-        
+
         return Result<GameMemberDto>.Success(new GameMemberDto(gameMember));
     }
 }

--- a/SecretSantaServer/SecretSantaServer/src/Services/GameService.cs
+++ b/SecretSantaServer/SecretSantaServer/src/Services/GameService.cs
@@ -1,19 +1,32 @@
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.EntityFrameworkCore;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Query.Expressions.Internal;
 using SecretSantaServer.Data;
 using SecretSantaServer.DTOs;
 using SecretSantaServer.Models;
 using SecretSantaServer.Enums;
+using SecretSantaServer.Hubs;
 
 namespace SecretSantaServer.Services;
 
 public class GameService : IGameService
 {
     private readonly ApplicationDbContext _dbContext;
+    private readonly IHubContext<GameHub> _hubContext;
     private const string CharsForCode = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private readonly string _gameStatusUpdateMethod;
+    private readonly string _userJoinMethod;
+    private readonly string _userExitMethod;
 
-    public GameService(ApplicationDbContext dbContext)
+    public GameService(ApplicationDbContext dbContext, IHubContext<GameHub> hubContextContext,
+        IConfiguration configuration)
     {
         _dbContext = dbContext;
+        _hubContext = hubContextContext;
+        _gameStatusUpdateMethod = configuration["Frontend:GameStatusUpdatedMethod"]!;
+        _userJoinMethod = configuration["Frontend:UserJoinMethod"]!;
+        _userExitMethod = configuration["Frontend:UserExitMethod"]!;
     }
 
     public async Task<Result<GameDto>> CreateGame(int adminId, CreateGameRequest request)
@@ -75,6 +88,11 @@ public class GameService : IGameService
         return Result<List<GameDto>>.Success(result);
     }
 
+    public async Task<bool> IsUserInGame(int gameId, int userId)
+    {
+        return await _dbContext.GameMembers.AnyAsync(gm => gm.GameId == gameId && gm.UserId == userId);
+    }
+
     public async Task<Result<GameDto>> GetGameById(int id)
     {
         var game = await _dbContext.Games
@@ -87,6 +105,12 @@ public class GameService : IGameService
             return Result<GameDto>.Failure("Game not found", StatusCodes.Status404NotFound);
 
         return Result<GameDto>.Success(new GameDto(game));
+    }
+
+    public async Task<GameStatus?> GetGameStatusById(int id)
+    {
+        var game = await _dbContext.Games.FirstOrDefaultAsync(x => x.Id == id);
+        return game?.Status;
     }
 
     public async Task<Result<GameDto>> UpdateGame(int gameId, UpdateGameRequest request, int userId)
@@ -132,26 +156,52 @@ public class GameService : IGameService
         if (game.Status != expectedStatus)
             return Result<GameDto>.Failure($"Game status not {expectedStatus}. Current status: {game.Status}",
                 StatusCodes.Status400BadRequest);
-
-        game.Status = newStatus;
-        if (newStatus == GameStatus.Started || newStatus == GameStatus.Cancelled)
+        if (newStatus == GameStatus.Started)
         {
-            game.Code = null;
-            game.ScheduledAt = null;
+            var participants = game.GameMembers.Count;
+            if (!game.IsAdminParticipating)
+                participants--;
+            if (participants < 3)
+                return Result<GameDto>.Failure("Too few players to start", StatusCodes.Status400BadRequest);
         }
 
-        if (newStatus == GameStatus.Started)
-            game.StartedAt = DateTime.UtcNow;
-        if (newStatus == GameStatus.Finished)
-            game.FinishedAt = DateTime.UtcNow;
-        await _dbContext.SaveChangesAsync();
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync();
+        try
+        {
+            game.Status = newStatus;
+            if (newStatus == GameStatus.Started || newStatus == GameStatus.Cancelled)
+            {
+                game.Code = null;
+                game.ScheduledAt = null;
+            }
 
-        return Result<GameDto>.Success(new GameDto(game));
+            if (newStatus == GameStatus.Started)
+            {
+                StartGame(game);
+                game.StartedAt = DateTime.UtcNow;
+            }
+
+            if (newStatus == GameStatus.Finished)
+                game.FinishedAt = DateTime.UtcNow;
+            await _dbContext.SaveChangesAsync();
+
+            await _hubContext.Clients.Group($"game-{gameId}")
+                .SendAsync(_gameStatusUpdateMethod, new EventDto<int>($"game-{newStatus}", gameId));
+
+            await transaction.CommitAsync();
+            return Result<GameDto>.Success(new GameDto(game));
+        }
+        catch (Exception ex)
+        {
+            await transaction.RollbackAsync();
+            return Result<GameDto>.Failure(ex.Message, StatusCodes.Status500InternalServerError);
+        }
     }
 
     public async Task<Result<GameDto>> JoinGame(string gameCode, int userId, string? wishLetter)
     {
-        if (await _dbContext.Users.AllAsync(x => x.Id != userId))
+        var user = await _dbContext.Users.AsNoTracking().FirstOrDefaultAsync(x => x.Id == userId);
+        if (user == null)
             return Result<GameDto>.Failure($"User {userId} not found", StatusCodes.Status404NotFound);
 
         var game = await _dbContext.Games.Include(x => x.GameMembers)
@@ -171,6 +221,9 @@ public class GameService : IGameService
         _dbContext.GameMembers.Add(newMember);
         await _dbContext.SaveChangesAsync();
 
+        await _hubContext.Clients.Group($"game-{game.Id}")
+            .SendAsync(_userJoinMethod, new EventDto<UserProfileDto>($"user-joined", new UserProfileDto(user)));
+
         return Result<GameDto>.Success(new GameDto(game));
     }
 
@@ -182,8 +235,8 @@ public class GameService : IGameService
         if (game == null)
             return Result<GameDto>.Failure($"Game {gameId} not found", StatusCodes.Status404NotFound);
 
-        var user = game.GameMembers.FirstOrDefault(m => m.UserId == userId);
-        if (user == null)
+        var gameMember = game.GameMembers.FirstOrDefault(m => m.UserId == userId);
+        if (gameMember == null)
             return Result<GameDto>.Failure($"User {userId} not found in game", StatusCodes.Status404NotFound);
 
         if (userId == game.AdminId)
@@ -193,8 +246,12 @@ public class GameService : IGameService
             return Result<GameDto>.Failure("You can't exit after the game has started.",
                 StatusCodes.Status400BadRequest);
 
-        _dbContext.GameMembers.Remove(user);
+        _dbContext.GameMembers.Remove(gameMember);
         await _dbContext.SaveChangesAsync();
+
+        var user = await _dbContext.Users.AsNoTracking().FirstOrDefaultAsync(x => x.Id == userId);
+        await _hubContext.Clients.Group($"game-{game.Id}")
+            .SendAsync(_userExitMethod, new EventDto<UserProfileDto>($"user-exit", new UserProfileDto(user!)));
 
         return Result<GameDto>.Success(new GameDto(game));
     }
@@ -242,5 +299,46 @@ public class GameService : IGameService
         } while (await _dbContext.Games.AnyAsync(g => g.Code == code));
 
         return code;
+    }
+
+    private void StartGame(Game game)
+    {
+        var members = game.GameMembers.Where(x => x.UserId != game.AdminId || game.IsAdminParticipating)
+            .Select(x=>x.Id).ToList();
+        members.Shuffle();
+        for (var i = 1; i < members.Count; i++)
+        {
+            var assignment = new Assignment()
+            {
+                GameId = game.Id,
+                RecipientId = members[i],
+                SantaId = members[i-1],
+            };
+            _dbContext.Assignments.Add(assignment);
+        }
+
+        var assignment2 = new Assignment()
+        {
+            GameId = game.Id,
+            RecipientId = members[0],
+            SantaId = members[^1],
+        };
+        _dbContext.Assignments.Add(assignment2);
+    }
+}
+
+public static class ShuffleExtension
+{
+    private static Random rng = new Random();
+
+    public static void Shuffle<T>(this IList<T> list)
+    {
+        var n = list.Count;
+        while (n > 1)
+        {
+            n--;
+            var k = rng.Next(n + 1);
+            (list[k], list[n]) = (list[n], list[k]);
+        }
     }
 }

--- a/SecretSantaServer/SecretSantaServer/src/Services/IAssignmentService.cs
+++ b/SecretSantaServer/SecretSantaServer/src/Services/IAssignmentService.cs
@@ -5,6 +5,7 @@ namespace SecretSantaServer.Services;
 
 public interface IAssignmentService
 {
-    Task<Result<GameMemberDto>> GetWishLetter(int gameId, int userId, int requesterId);
+    Task<Result<GameMemberDto>> GetMyWishLetter(int gameId, int userId);
+    Task<Result<GameMemberDto>> GetParticipantWishLetter(int gameId, int userId);
     Task<Result<GameMemberDto>> ChangeWishLetter(int gameId, int userId, string wishLetter);
 }

--- a/SecretSantaServer/SecretSantaServer/src/Services/IGameService.cs
+++ b/SecretSantaServer/SecretSantaServer/src/Services/IGameService.cs
@@ -8,7 +8,9 @@ public interface IGameService
 {
     Task<Result<GameDto>> CreateGame(int adminId, CreateGameRequest request);
     Task<Result<List<GameDto>>> GetUserGames(int id);
+    Task<bool> IsUserInGame(int gameId, int userId);
     Task<Result<GameDto>> GetGameById(int id);
+    Task<GameStatus?> GetGameStatusById(int id);
     Task<Result<GameDto>> UpdateGame(int gameId, UpdateGameRequest request, int userId);
     Task<Result<GameDto>> ChangeStatusGame(int gameId, int userId, GameStatus expectedStatus, GameStatus newStatus);
     Task<Result<GameDto>> JoinGame(string gameCode, int userId, string? wishLetter);


### PR DESCRIPTION
- Set up SSE endpoint at GET /api/games/{id}/events (#85)
    - Implement connection management and automatic reconnection handling (#86)
    - Add JWT authentication for SSE connections (#87)
    - Create centralized event broadcasting system using SignalR (#88)
    - Implement participant-joined event with EventDto payload (#89)
    - Implement participant-left event to notify clients on user exit (#90)
    - Implement game-started event to signal game lifecycle start (#91)
    - Implement game-revealed event for post-game status updates (#92)
    - Handle connection timeouts (#93)
    - Add Santa assignment distribution logic: shuffle participants