### PR TITLE
feat: implement frontend game creation and list (#68)

### DIFF
--- a/secret-santa/src/App.css
+++ b/secret-santa/src/App.css
@@ -1,5 +1,6 @@
 @import url('./auth/auth.css');
 @import url('./pages/pages.css');
+@import url('./game/game.css');
 
 body {
   margin: 0;

--- a/secret-santa/src/game/GameCard.tsx
+++ b/secret-santa/src/game/GameCard.tsx
@@ -1,0 +1,80 @@
+import type { Game } from '../types';
+
+interface GameCardProps {
+  game: Game;
+}
+
+const GameCard = (props: GameCardProps) => {
+  // Function to get status badge class based on game status
+  const getStatusClass = (status: string) => {
+    switch (status) {
+      case 'draft':
+        return 'status-draft';
+      case 'active':
+        return 'status-active';
+      case 'completed':
+        return 'status-completed';
+      case 'cancelled':
+        return 'status-cancelled';
+      default:
+        return 'status-unknown';
+    }
+  };
+
+  // Function to format date
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return 'Not set';
+    return new Date(dateString).toLocaleDateString();
+  };
+
+  return (
+    <div class="game-card">
+      <div class="game-card-header">
+        <h3 class="game-name">{props.game.name}</h3>
+        <span class={`status-badge ${getStatusClass(props.game.status)}`}>
+          {props.game.status.charAt(0).toUpperCase() + props.game.status.slice(1)}
+        </span>
+      </div>
+      
+      {props.game.description && (
+        <p class="game-description">{props.game.description}</p>
+      )}
+      
+      <div class="game-details">
+        <div class="detail-item">
+          <span class="detail-label">Creator:</span>
+          <span class="detail-value">{props.game.creatorName}</span>
+        </div>
+        
+        <div class="detail-item">
+          <span class="detail-label">Participants:</span>
+          <span class="detail-value">
+            {props.game.participantCount}/{props.game.participantLimit}
+          </span>
+        </div>
+        
+        {props.game.startDate && (
+          <div class="detail-item">
+            <span class="detail-label">Starts:</span>
+            <span class="detail-value">{formatDate(props.game.startDate)}</span>
+          </div>
+        )}
+        
+        {props.game.endDate && (
+          <div class="detail-item">
+            <span class="detail-label">Ends:</span>
+            <span class="detail-value">{formatDate(props.game.endDate)}</span>
+          </div>
+        )}
+      </div>
+      
+      <div class="game-card-footer">
+        <a href={`/games/${props.game.id}`} class="view-details-link">
+          View Details
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default GameCard;

--- a/secret-santa/src/game/GameCreationForm.tsx
+++ b/secret-santa/src/game/GameCreationForm.tsx
@@ -1,0 +1,139 @@
+import { createSignal } from 'solid-js';
+import type { CreateGameRequest, Game } from '../types';
+import gamesService from '../services/games.service';
+
+interface GameCreationFormProps {
+  onClose: () => void;
+  onSuccess: (game: Game) => void;
+}
+
+const GameCreationForm = (props: GameCreationFormProps) => {
+  const [name, setName] = createSignal('');
+  const [description, setDescription] = createSignal('');
+  const [participantLimit, setParticipantLimit] = createSignal<number>(10);
+  const [startDate, setStartDate] = createSignal('');
+  const [endDate, setEndDate] = createSignal('');
+  const [error, setError] = createSignal('');
+  const [loading, setLoading] = createSignal(false);
+
+  const handleSubmit = async (e: SubmitEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      const gameData: CreateGameRequest = {
+        name: name(),
+        description: description() || undefined,
+        participantLimit: participantLimit(),
+        startDate: startDate() || undefined,
+        endDate: endDate() || undefined,
+      };
+
+      const newGame = await gamesService.createGame(gameData);
+      props.onSuccess(newGame);
+      props.onClose();
+    } catch (err: any) {
+      setError(err.response?.data?.message || 'Failed to create game');
+      console.error('Error creating game:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div class="game-creation-form-overlay">
+      <div class="game-creation-form">
+        <div class="form-header">
+          <h2>Create New Game</h2>
+          <button class="close-button" onClick={props.onClose} disabled={loading()}>
+            &times;
+          </button>
+        </div>
+        
+        {error() && (
+          <div class="error-message">
+            {error()}
+          </div>
+        )}
+        
+        <form onSubmit={handleSubmit}>
+          <div class="form-group">
+            <label for="game-name">Game Name *</label>
+            <input
+              id="game-name"
+              type="text"
+              value={name()}
+              onInput={(e) => setName(e.currentTarget.value)}
+              required
+              disabled={loading()}
+              placeholder="Enter game name"
+            />
+          </div>
+          
+          <div class="form-group">
+            <label for="game-description">Description</label>
+            <textarea
+              id="game-description"
+              value={description()}
+              onInput={(e) => setDescription(e.currentTarget.value)}
+              disabled={loading()}
+              placeholder="Enter game description"
+              rows={3}
+            />
+          </div>
+          
+          <div class="form-group">
+            <label for="participant-limit">Participant Limit *</label>
+            <input
+              id="participant-limit"
+              type="number"
+              min="3"
+              max="100"
+              value={participantLimit()}
+              onInput={(e) => setParticipantLimit(Number(e.currentTarget.value))}
+              required
+              disabled={loading()}
+            />
+          </div>
+          
+          <div class="form-row">
+            <div class="form-group">
+              <label for="start-date">Start Date</label>
+              <input
+                id="start-date"
+                type="date"
+                value={startDate()}
+                onInput={(e) => setStartDate(e.currentTarget.value)}
+                disabled={loading()}
+              />
+            </div>
+            
+            <div class="form-group">
+              <label for="end-date">End Date</label>
+              <input
+                id="end-date"
+                type="date"
+                value={endDate()}
+                onInput={(e) => setEndDate(e.currentTarget.value)}
+                disabled={loading()}
+                min={startDate() || undefined}
+              />
+            </div>
+          </div>
+          
+          <div class="form-actions">
+            <button type="button" onClick={props.onClose} disabled={loading()}>
+              Cancel
+            </button>
+            <button type="submit" disabled={loading()}>
+              {loading() ? 'Creating...' : 'Create Game'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default GameCreationForm;

--- a/secret-santa/src/game/GameDetailsPage.tsx
+++ b/secret-santa/src/game/GameDetailsPage.tsx
@@ -1,0 +1,196 @@
+import { createSignal, onMount } from 'solid-js';
+import { useParams } from '@solidjs/router';
+import type { Game } from '../types';
+import gamesService from '../services/games.service';
+import { useAuth } from '../AuthProvider';
+
+const GameDetailsPage = () => {
+  const params = useParams();
+  const { user } = useAuth();
+  const [game, setGame] = createSignal<Game | null>(null);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal('');
+
+  onMount(async () => {
+    try {
+      setLoading(true);
+      setError('');
+      const gameId = params.id;
+      if (!gameId) {
+        setError('Game ID is required');
+        return;
+      }
+      const gameData = await gamesService.getGameById(gameId);
+      setGame(gameData);
+    } catch (err) {
+      setError('Failed to load game details');
+      console.error('Error loading game details:', err);
+    } finally {
+      setLoading(false);
+    }
+  });
+
+  const joinGame = async () => {
+    if (!game()) return;
+    
+    try {
+      setLoading(true);
+      const updatedGame = await gamesService.joinGame(game()!.id);
+      setGame(updatedGame);
+    } catch (err) {
+      setError('Failed to join game');
+      console.error('Error joining game:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const leaveGame = async () => {
+    if (!game()) return;
+    
+    try {
+      setLoading(true);
+      const updatedGame = await gamesService.leaveGame(game()!.id);
+      setGame(updatedGame);
+    } catch (err) {
+      setError('Failed to leave game');
+      console.error('Error leaving game:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (loading()) {
+    return <div class="loading">Loading game details...</div>;
+  }
+
+  if (error()) {
+    return (
+      <div class="error-message">
+        {error()}
+        <a href="/games">Back to Games</a>
+      </div>
+    );
+  }
+
+  const currentGame = game();
+  if (!currentGame) {
+    return (
+      <div class="error-message">
+        Game not found
+        <a href="/games">Back to Games</a>
+      </div>
+    );
+  }
+
+  // Function to get status badge class based on game status
+  const getStatusClass = (status: string) => {
+    switch (status) {
+      case 'draft':
+        return 'status-draft';
+      case 'active':
+        return 'status-active';
+      case 'completed':
+        return 'status-completed';
+      case 'cancelled':
+        return 'status-cancelled';
+      default:
+        return 'status-unknown';
+    }
+  };
+
+  // Function to format date
+  const formatDate = (dateString?: string) => {
+    if (!dateString) return 'Not set';
+    return new Date(dateString!).toLocaleDateString();
+  };
+
+  return (
+    <div class="game-details-page">
+      <header class="game-details-header">
+        <a href="/games" class="back-link">&larr; Back to Games</a>
+        <div class="game-header-content">
+          <h1>{currentGame.name}</h1>
+          <span class={`status-badge ${getStatusClass(currentGame.status)}`}>
+            {currentGame.status.charAt(0).toUpperCase() + currentGame.status.slice(1)}
+          </span>
+        </div>
+      </header>
+
+      {error() && (
+        <div class="error-message">
+          {error()}
+        </div>
+      )}
+
+      <main class="game-details-main">
+        <section class="game-info">
+          <div class="game-basic-info">
+            {currentGame.description && (
+              <div class="game-description">
+                <h3>Description</h3>
+                <p>{currentGame.description}</p>
+              </div>
+            )}
+
+            <div class="game-stats">
+              <div class="stat-card">
+                <h4>Participants</h4>
+                <p>{currentGame.participantCount} / {currentGame.participantLimit}</p>
+              </div>
+              
+              <div class="stat-card">
+                <h4>Creator</h4>
+                <p>{currentGame.creatorName}</p>
+              </div>
+              
+              {currentGame.startDate && (
+                <div class="stat-card">
+                  <h4>Start Date</h4>
+                  <p>{formatDate(currentGame.startDate)}</p>
+                </div>
+              )}
+              
+              {currentGame.endDate && (
+                <div class="stat-card">
+                  <h4>End Date</h4>
+                  <p>{formatDate(currentGame.endDate)}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section class="game-actions">
+          {user && currentGame.isParticipant ? (
+            <div class="action-buttons">
+              <button 
+                class="leave-game-btn" 
+                onClick={leaveGame}
+                disabled={loading()}
+              >
+                {loading() ? 'Leaving...' : 'Leave Game'}
+              </button>
+            </div>
+          ) : user && !currentGame.isCreator ? (
+            <div class="action-buttons">
+              <button 
+                class="join-game-btn" 
+                onClick={joinGame}
+                disabled={loading()}
+              >
+                {loading() ? 'Joining...' : 'Join Game'}
+              </button>
+            </div>
+          ) : (
+            <div class="action-info">
+              <p>You created this game</p>
+            </div>
+          )}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default GameDetailsPage;

--- a/secret-santa/src/game/GamesListPage.tsx
+++ b/secret-santa/src/game/GamesListPage.tsx
@@ -1,0 +1,108 @@
+import { createSignal, onMount } from 'solid-js';
+import type { Game, GameFilter } from '../types';
+import gamesService from '../services/games.service';
+import GameCard from '../game/GameCard';
+import GameCreationForm from './GameCreationForm';
+
+const GamesListPage = () => {
+  const [games, setGames] = createSignal<Game[]>([]);
+  const [loading, setLoading] = createSignal(true);
+  const [error, setError] = createSignal('');
+  const [filter, setFilter] = createSignal<GameFilter>({ type: 'all' });
+  const [showCreateModal, setShowCreateModal] = createSignal(false);
+
+  onMount(() => {
+    loadGames();
+  });
+
+  const loadGames = async () => {
+    try {
+      setLoading(true);
+      setError('');
+      const gamesData = await gamesService.getGames(filter());
+      setGames(gamesData);
+    } catch (err) {
+      setError('Failed to load games');
+      console.error('Error loading games:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleFilterChange = (type: 'all' | 'created' | 'participating') => {
+    setFilter({ type });
+    // Reset pagination if applicable
+    loadGames();
+  };
+
+  const handleGameCreated = (newGame: Game) => {
+    // Add the new game to the list
+    setGames([newGame, ...games()]);
+    setShowCreateModal(false);
+  };
+
+  return (
+    <div class="games-list-page">
+      <header class="games-header">
+        <h1>Your Games</h1>
+        <button class="create-game-button" onClick={() => setShowCreateModal(true)}>
+          Create Game
+        </button>
+      </header>
+
+      <div class="games-filters">
+        <button 
+          class={`filter-btn ${filter().type === 'all' ? 'active' : ''}`}
+          onClick={() => handleFilterChange('all')}
+        >
+          All Games
+        </button>
+        <button 
+          class={`filter-btn ${filter().type === 'created' ? 'active' : ''}`}
+          onClick={() => handleFilterChange('created')}
+        >
+          Created by Me
+        </button>
+        <button 
+          class={`filter-btn ${filter().type === 'participating' ? 'active' : ''}`}
+          onClick={() => handleFilterChange('participating')}
+        >
+          Participating
+        </button>
+      </div>
+
+      {error() && (
+        <div class="error-message">
+          {error()}
+        </div>
+      )}
+
+      {loading() ? (
+        <div class="loading">Loading games...</div>
+      ) : (
+        <div class="games-grid">
+          {games().length > 0 ? (
+            games().map((game) => (
+              <GameCard game={game} />
+            ))
+          ) : (
+            <div class="no-games">
+              <p>No games found. {filter().type === 'all' ? 'Create your first game!' : 'Try changing your filter.'}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {showCreateModal() && (
+        <div class="modal-overlay">
+          <GameCreationForm 
+            onClose={() => setShowCreateModal(false)} 
+            onSuccess={handleGameCreated} 
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GamesListPage;

--- a/secret-santa/src/game/game.css
+++ b/secret-santa/src/game/game.css
@@ -1,0 +1,437 @@
+/* Games List Page */
+.games-list-page {
+  padding: 20px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.games-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 30px;
+}
+
+.games-header h1 {
+  margin: 0;
+  color: #333;
+}
+
+.create-game-button {
+  background-color: #007bff;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.create-game-button:hover {
+  background-color: #0056b3;
+}
+
+.games-filters {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.filter-btn {
+  padding: 8px 16px;
+  border: 1px solid #ddd;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.filter-btn.active {
+  background-color: #007bff;
+  color: white;
+  border-color: #007bff;
+}
+
+.filter-btn:hover {
+  background-color: #f8f9fa;
+}
+
+.games-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 20px;
+}
+
+.no-games {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+}
+
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+}
+
+/* Game Card */
+.game-card {
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 20px;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  transition: box-shadow 0.2s;
+}
+
+.game-card:hover {
+  box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+
+.game-card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 15px;
+}
+
+.game-name {
+  margin: 0 0 5px 0;
+  font-size: 1.2em;
+  color: #333;
+}
+
+.status-badge {
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 0.8em;
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.status-draft {
+  background-color: #fff3cd;
+  color: #856404;
+}
+
+.status-active {
+  background-color: #d4edda;
+  color: #155724;
+}
+
+.status-completed {
+  background-color: #cce5ff;
+  color: #004085;
+}
+
+.status-cancelled {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+
+.game-description {
+  margin: 10px 0;
+  color: #666;
+  line-height: 1.5;
+}
+
+.game-details {
+  margin: 15px 0;
+}
+
+.detail-item {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  font-size: 0.9em;
+}
+
+.detail-label {
+  font-weight: bold;
+  color: #555;
+}
+
+.detail-value {
+  color: #333;
+}
+
+.game-card-footer {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #eee;
+}
+
+.view-details-link {
+  display: inline-block;
+  background-color: #007bff;
+  color: white;
+  padding: 8px 16px;
+  text-decoration: none;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.view-details-link:hover {
+  background-color: #0056b3;
+}
+
+/* Game Creation Form */
+.game-creation-form-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.game-creation-form {
+  background: white;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 500px;
+  padding: 25px;
+  position: relative;
+}
+
+.form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.form-header h2 {
+  margin: 0;
+  color: #333;
+}
+
+.close-button {
+  background: none;
+  border: none;
+  font-size: 1.5em;
+  cursor: pointer;
+  color: #999;
+}
+
+.close-button:hover {
+  color: #333;
+}
+
+.form-group {
+  margin-bottom: 15px;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 5px;
+  font-weight: 500;
+  color: #555;
+}
+
+.form-group input,
+.form-group textarea {
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 16px;
+  box-sizing: border-box;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 15px;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.form-actions button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+.form-actions button[type="button"] {
+  background-color: #6c757d;
+  color: white;
+}
+
+.form-actions button[type="button"]:hover {
+  background-color: #5a6268;
+}
+
+.form-actions button[type="submit"] {
+  background-color: #007bff;
+  color: white;
+}
+
+.form-actions button[type="submit"]:hover {
+  background-color: #0056b3;
+}
+
+/* Game Details Page */
+.game-details-page {
+  padding: 20px;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.game-details-header {
+  margin-bottom: 30px;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 15px;
+  color: #007bff;
+  text-decoration: none;
+}
+
+.back-link:hover {
+  text-decoration: underline;
+}
+
+.game-header-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.game-header-content h1 {
+  margin: 0;
+  color: #333;
+}
+
+.game-details-main {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.game-info {
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 25px;
+}
+
+.game-basic-info {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.game-description h3 {
+  margin-top: 0;
+  color: #333;
+}
+
+.game-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 15px;
+}
+
+.stat-card {
+  border: 1px solid #eee;
+  border-radius: 4px;
+  padding: 15px;
+  text-align: center;
+}
+
+.stat-card h4 {
+  margin: 0 0 10px 0;
+  color: #555;
+  font-size: 0.9em;
+}
+
+.stat-card p {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #333;
+}
+
+.game-actions {
+  background: white;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 25px;
+}
+
+.action-buttons {
+  display: flex;
+  justify-content: center;
+}
+
+.action-buttons button {
+  padding: 12px 24px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+  min-width: 150px;
+}
+
+.join-game-btn {
+  background-color: #28a745;
+  color: white;
+}
+
+.join-game-btn:hover:not(:disabled) {
+  background-color: #218838;
+}
+
+.leave-game-btn {
+  background-color: #dc3545;
+  color: white;
+}
+
+.leave-game-btn:hover:not(:disabled) {
+  background-color: #c82333;
+}
+
+.action-info {
+  text-align: center;
+  padding: 20px;
+  color: #666;
+}
+
+.action-buttons button:disabled {
+  background-color: #6c757d;
+  cursor: not-allowed;
+}
+
+/* Modal Overlay */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}

--- a/secret-santa/src/routes.tsx
+++ b/secret-santa/src/routes.tsx
@@ -10,6 +10,8 @@ const RegisterPage = lazy(() => import('./pages/Register'));
 const DashboardPage = lazy(() => import('./pages/Dashboard'));
 const ProfilePage = lazy(() => import('./pages/Profile'));
 const OAuthCallbackPage = lazy(() => import('./auth/OAuthCallback'));
+const GamesListPage = lazy(() => import('./game/GamesListPage'));
+const GameDetailsPage = lazy(() => import('./game/GameDetailsPage'));
 
 const AppRoutes = () => {
   return (
@@ -28,6 +30,16 @@ const AppRoutes = () => {
       <Route path="/profile" component={() => (
         <ProtectedRoute>
           <ProfilePage />
+        </ProtectedRoute>
+      )} />
+      <Route path="/games" component={() => (
+        <ProtectedRoute>
+          <GamesListPage />
+        </ProtectedRoute>
+      )} />
+      <Route path="/games/:id" component={() => (
+        <ProtectedRoute>
+          <GameDetailsPage />
         </ProtectedRoute>
       )} />
     </Router>

--- a/secret-santa/src/services/games.service.ts
+++ b/secret-santa/src/services/games.service.ts
@@ -1,0 +1,53 @@
+import axios from 'axios';
+import { API_BASE_URL } from './api';
+import type { CreateGameRequest, Game, GameFilter } from '../types';
+
+class GamesService {
+  private baseUrl: string;
+
+  constructor() {
+    this.baseUrl = `${API_BASE_URL}/games`;
+  }
+
+  async getGames(filter?: GameFilter): Promise<Game[]> {
+    const params = new URLSearchParams();
+    
+    if (filter?.type) {
+      params.append('type', filter.type);
+    }
+
+    const response = await axios.get(`${this.baseUrl}?${params.toString()}`);
+    return response.data;
+  }
+
+  async getGameById(id: string): Promise<Game> {
+    const response = await axios.get(`${this.baseUrl}/${id}`);
+    return response.data;
+  }
+
+  async createGame(gameData: CreateGameRequest): Promise<Game> {
+    const response = await axios.post(this.baseUrl, gameData);
+    return response.data;
+  }
+
+  async updateGame(id: string, gameData: Partial<CreateGameRequest>): Promise<Game> {
+    const response = await axios.put(`${this.baseUrl}/${id}`, gameData);
+    return response.data;
+  }
+
+  async deleteGame(id: string): Promise<void> {
+    await axios.delete(`${this.baseUrl}/${id}`);
+  }
+
+  async joinGame(gameId: string): Promise<Game> {
+    const response = await axios.post(`${this.baseUrl}/${gameId}/join`);
+    return response.data;
+  }
+
+  async leaveGame(gameId: string): Promise<Game> {
+    const response = await axios.post(`${this.baseUrl}/${gameId}/leave`);
+    return response.data;
+  }
+}
+
+export default new GamesService();

--- a/secret-santa/src/types/index.ts
+++ b/secret-santa/src/types/index.ts
@@ -31,3 +31,33 @@ export interface TelegramAuthData {
   auth_date: number;
   hash: string;
 }
+
+// Game-related types
+export interface Game {
+  id: string;
+  name: string;
+  description?: string;
+  creatorId: string;
+  creatorName: string;
+  status: 'draft' | 'active' | 'completed' | 'cancelled';
+  participantLimit: number;
+  participantCount: number;
+  startDate?: string;
+  endDate?: string;
+  createdAt: string;
+  updatedAt: string;
+  isParticipant: boolean;
+  isCreator: boolean;
+}
+
+export interface CreateGameRequest {
+  name: string;
+  description?: string;
+  participantLimit: number;
+  startDate?: string;
+  endDate?: string;
+}
+
+export interface GameFilter {
+  type?: 'created' | 'participating' | 'all';
+}


### PR DESCRIPTION
This PR implements the complete frontend game creation and list functionality as requested in issue #68. The
  implementation includes all sub-tasks:

   - Create game creation modal/form (#69)
   - Implement games list page (#70)
   - Add game cards with status badges (#71)
   - Filter games (created by me / participating) (#72)
   - Display participant count (#73)
   - Add navigation to game details (#74)

  Key features:
   - Game creation modal with form validation
   - Games list page with filtering capabilities
   - Game cards with status badges and participant counts
   - Filter options for created games vs participating games
   - Navigation to detailed game view
   - Responsive UI components with proper styling
   - Integration with the games service API

  Technical details:
   - Uses Solid.js for UI components
   - Implements proper TypeScript typing throughout
   - Includes game-related types and service layer
   - Responsive design with CSS styling
   - Proper error handling and loading states